### PR TITLE
exclude a .m file from target

### DIFF
--- a/ios/lelantus.podspec
+++ b/ios/lelantus.podspec
@@ -13,7 +13,8 @@ A new flutter plugin project.
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
+#  s.source_files = 'Classes/**/*'
+  s.source_files = 'Classes/FlutterLiblelantusPlugin.h','Classes/LelantusPlugin.h','Classes/LelantusPlugin.m','Classes/SwiftFlutterLelantusPlugin.swift','Classes/SwiftLelantusPlugin.swift'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
 


### PR DESCRIPTION
Prevent having to manually uncheck lelantus target membership in xcode during build process