### PR TITLE
Use bash instead of sh in mxedeps script because it uses bash feature…

### DIFF
--- a/scripts/windows/mxedeps.sh
+++ b/scripts/windows/mxedeps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # MXE dependencies
 sudo apt-get install -y p7zip-full \


### PR DESCRIPTION
Use bash instead of sh in mxedeps script because it uses bash features like [[ that aren't in sh.