### PR TITLE
Exit if errors in windows build.

### DIFF
--- a/scripts/windows/build_all.sh
+++ b/scripts/windows/build_all.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-./build_openssl.sh
-./prep_sharedfile.sh
+./build_openssl.sh || exit
+./prep_sharedfile.sh || exit
 
-cd build
+cd build || exit
 rm CMakeCache.txt
 x86_64-w64-mingw32.static-cmake ./mobileliblelantus -DCMAKE_BUILD_TYPE=RelWithDebInfo
 make -j$(nproc)


### PR DESCRIPTION
All this build stuff should be reworked more consistently, but this will at least help a recent issue.