### PR TITLE
corrected iOS build scripts for more robust building chances of success

### DIFF
--- a/scripts/ios/build_lib.sh
+++ b/scripts/ios/build_lib.sh
@@ -13,7 +13,11 @@ COMMIT=$(git log -1 --pretty=format:"%H")
 OS="IOS"
 sed -i '' "/\/\*${OS}_VERSION/c\\/\*${OS}_VERSION\*\/ const ${OS}_VERSION = \"$COMMIT\";" $VERSIONS_FILE
 cd $MOBILE_LIB_ROOT
-cmake . -DCMAKE_TOOLCHAIN_FILE="${IOS_TOOLCHAIN_ROOT}/toolchain/iOS.cmake" && make -j4
+
+LIBRARY_PATH="" LD_LIBRARY_PATH="" cmake . \
+  -DCMAKE_TOOLCHAIN_FILE="${IOS_TOOLCHAIN_ROOT}/toolchain/iOS.cmake" \
+  -DCMAKE_OSX_ARCHITECTURES="arm64" \
+  && LIBRARY_PATH="" LD_LIBRARY_PATH="" make -j4
 
 plutil -replace CFBundleShortVersionString -string "0.0.2" ./mobileliblelantus.framework/Info.plist
 plutil -replace CFBundleVersion -string "1" ./mobileliblelantus.framework/Info.plist

--- a/scripts/ios/build_openssl.sh
+++ b/scripts/ios/build_openssl.sh
@@ -13,7 +13,7 @@ cd "$OPEN_SSL_DIR_PATH" || exit 1
 git checkout b77ace70b2594de69c88d0748326d2a1190bbac1
 sed -i '' "s/IOS_MIN_SDK_VERSION=\"12.0\"/IOS_MIN_SDK_VERSION=\"10.0\"/g" build-libssl.sh
 
-CURL_OPTIONS="-L" ./build-libssl.sh --version=1.1.1k --archs="x86_64 arm64 armv7s armv7" --targets="ios64-cross-arm64 ios-cross-armv7 ios-cross-armv7s" --deprecated
+CURL_OPTIONS="-L" ./build-libssl.sh --version=1.1.1k --archs="x86_64 arm64" --targets="ios64-cross-arm64" --deprecated
 
 mv "${OPEN_SSL_DIR_PATH}"/include/* "$EXTERNAL_IOS_INCLUDE_DIR"
 mv "${OPEN_SSL_DIR_PATH}"/lib/* "$EXTERNAL_IOS_LIB_DIR"


### PR DESCRIPTION
If there are issues with eliminating armv7 from the OpenSSL build, let me know. I did this because of build issues on my M4 mac mini, and the fact that iOS 11.0 dropped support for armv7, while the script sets the minimum iOS SDK version for liblelantus to 11 a few lines lower.