### PR TITLE
Remove empty placeholder libmobileliblelantus.so file.

### DIFF
--- a/scripts/linux/build_all.sh
+++ b/scripts/linux/build_all.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-mkdir build
+mkdir -p build
 ./build_openssl.sh
 ./copymobile.sh
 ./linkDistros.sh


### PR DESCRIPTION
- Remove empty placeholder libmobileliblelantus.so file.
- Only attempt to create linux build directory if it doesn't exist.