### PR TITLE
Fix build on Mac.

### DIFF
--- a/scripts/macos/CMakeLists/secp256k1/template_CMakeLists.txt
+++ b/scripts/macos/CMakeLists/secp256k1/template_CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2017 The Bitcoin developers
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(secp256k1)
 
 SET(distribution_DIR /opt/android)

--- a/scripts/macos/build_openssl_common.sh
+++ b/scripts/macos/build_openssl_common.sh
@@ -20,7 +20,7 @@ build_openssl_init_common() {
 
 	cd $EXTERNAL_MACOS_SOURCE_DIR
 	curl -O -L https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
-	echo "${OPENSSL_SHA256} openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum --check
+	(echo "${OPENSSL_SHA256} openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum --check) || echo "$OPENSSL_SHA256" | sha256sum -c openssl-"$OPENSSL_VERSION".tar.gz
 	tar -xvzf openssl-$OPENSSL_VERSION.tar.gz
 	rm -rf $DIR
 	rm -rf $OPEN_SSL_DIR_PATH


### PR DESCRIPTION
This commit fixes an issue with the formatting of input to sha256sum on Mac, and upgrades the CMakeLists.txt file to have a minimum version of 3.5 to allow compatibility with CMake on Mac.